### PR TITLE
Fix GetKeys

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -55,7 +55,7 @@ func TestClientGetKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if len(ids) <= len(keys) {
-		t.Errorf("expected len(ids)<=len(keys): %d<=%d", len(ids), len(keys))
+	if len(keys) < len(ids) {
+		t.Errorf("expected len(keys)<len(ids): %d<%d", len(keys), len(ids))
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -68,5 +68,5 @@ func ExampleWithSksKeyserversPool() {
 	hash := fmt.Sprintf("%x", md5.Sum(buf))
 	fmt.Println("hash:", hash)
 	// Output:
-	// hash: 67b15cedc0dbed6dcf6fcb45ef38f712
+	// hash: 75a1f7a6b2c84c003e5d9b6151ba6891
 }


### PR DESCRIPTION
fix GetKeys return multiple armored keys bytes, currently when it pass
to `openpgp.ReadArmoredKeyring` will result only the first key is read

modify the code to use `armor.Encode` to generate proper keys bytes